### PR TITLE
Add result request-id to response

### DIFF
--- a/flexibee-core/src/main/java/com/adleritech/flexibee/core/api/domain/Result.java
+++ b/flexibee-core/src/main/java/com/adleritech/flexibee/core/api/domain/Result.java
@@ -16,6 +16,9 @@ import org.simpleframework.xml.Root;
 @Root(strict = false)
 public class Result {
 
+    @Element(name = "request-id", required = false)
+    private String requestId;
+
     @Element(name = "id", required = false)
     private String id;
 


### PR DESCRIPTION
Flexibee ve své odpovědi vazbu na request vrací. Jen náš flexibeeClient ji doteď ignoroval.